### PR TITLE
python3-edgetpu: add already-stripped to INSANE_SKIP

### DIFF
--- a/recipes-support/python/python3-edgetpu.bb
+++ b/recipes-support/python/python3-edgetpu.bb
@@ -34,3 +34,5 @@ do_install_append_aarch64() {
 }
 
 BBCLASSEXTEND = "native nativesdk"
+
+INSANE_SKIP_${PN} += "already-stripped"


### PR DESCRIPTION
This module provides binary swig wrappers (cpp_wrapper), and they
are already stripped.

Signed-off-by: Mirza Krak <mirza@mkrak.org>