### PR TITLE
add python3-edgetpu-examples package

### DIFF
--- a/recipes-support/python/python3-edgetpu.bb
+++ b/recipes-support/python/python3-edgetpu.bb
@@ -9,8 +9,11 @@ S = "${WORKDIR}/git"
 PV = "release-chef"
 
 RDEPENDS_${PN} = "libedgetpu python3 python3-numpy python3-pillow"
+RDEPENDS_${PN}-examples = "bash ${PN}"
 
 inherit setuptools3
+
+PACKAGES += "${PN}-examples"
 
 do_install_append_x86_64() {
     rm ${D}${PYTHON_SITEPACKAGES_DIR}/edgetpu/swig/*arm-linux-gnueabihf*
@@ -32,6 +35,25 @@ do_install_append_aarch64() {
     mv ${D}${PYTHON_SITEPACKAGES_DIR}/edgetpu/swig/_edgetpu_cpp_wrapper.cpython-*-aarch64-linux-gnu.so \
        ${D}${PYTHON_SITEPACKAGES_DIR}/edgetpu/swig/_edgetpu_cpp_wrapper.so
 }
+
+do_install_append() {
+    install -d ${D}/${datadir}/edgetpu/examples/
+    install -d ${D}/${datadir}/edgetpu/examples/models
+    install -d ${D}/${datadir}/edgetpu/examples/images
+
+    cp -R --no-dereference --preserve=mode,links -v ${S}/test_data/*.jpg \
+        ${D}/${datadir}/edgetpu/examples/images
+
+    cp -R --no-dereference --preserve=mode,links -v ${S}/test_data/*.tflite \
+        ${D}/${datadir}/edgetpu/examples/models
+
+    cp -R --no-dereference --preserve=mode,links -v ${S}/test_data/*.txt \
+        ${D}/${datadir}/edgetpu/examples/models
+
+    cp -R --no-dereference --preserve=mode,links -v ${S}/edgetpu/demo/*  ${D}/${datadir}/edgetpu/examples/
+}
+
+FILES_${PN}-examples = "${datadir}/edgetpu/examples/"
 
 BBCLASSEXTEND = "native nativesdk"
 


### PR DESCRIPTION
This will install the example models and code to test things out on
the device, e.g:

    cd /usr/share/edgetpu/examples/

    python3 classify_image.py \
        --model models/mobilenet_v2_1.0_224_inat_bird_quant_edgetpu.tflite \
        --label models/inat_bird_labels.txt \
        --image images/parrot.jpg

Signed-off-by: Mirza Krak <mirza@mkrak.org>