### PR TITLE
Update coral-bootpart.wks.in for emmc flashing

### DIFF
--- a/meta-coral-bsp/wic/coral-bootpart.wks.in
+++ b/meta-coral-bsp/wic/coral-bootpart.wks.in
@@ -15,7 +15,7 @@
 #
 part u-boot --source rawcopy --sourceparams="file=imx-boot" --ondisk mmcblk --no-table --align ${IMX_BOOT_SEEK}
 part /boot --source bootimg-partition --ondisk mmcblk --fstype=ext4 --label boot --active --align 4096 --size 16
-part / --source rootfs --ondisk mmcblk --fstype=ext4 --label root --align 4096
+part / --source rootfs --ondisk mmcblk --fstype=ext4 --label root --align 4096 --uuid=70672ec3-5eee-49ff-b3b1-eb1fbd406bf5
 
-bootloader --ptable msdos
+bootloader --ptable gpt
 


### PR DESCRIPTION
According to this [issue](https://github.com/mirzak/meta-coral/issues/37), we were unable to flash the Coral emmc with the generated wic image and it was only compatible with an sdcard.
To make it compatible, I modified the [wks file ](https://github.com/mirzak/meta-coral/blob/master/meta-coral-bsp/wic/coral-bootpart.wks.in) to add a part uuid to correspond to the original coral mendel partitions and change bootloader partition table to gpt.

Works both on emmc and sdcard

Fixes #37 

Signed-off-by: Benjamin DELATTRE <benjamin.delattre@outlook.com>