### PR TITLE
Update coral-bootpart.wks.in

### DIFF
--- a/meta-coral-bsp/wic/coral-bootpart.wks.in
+++ b/meta-coral-bsp/wic/coral-bootpart.wks.in
@@ -15,7 +15,7 @@
 #
 part u-boot --source rawcopy --sourceparams="file=imx-boot" --ondisk mmcblk --no-table --align ${IMX_BOOT_SEEK}
 part /boot --source bootimg-partition --ondisk mmcblk --fstype=ext4 --label boot --active --align 4096 --size 16
-part / --source rootfs --ondisk mmcblk --fstype=ext4 --label root --align 4096
+part / --source rootfs --ondisk mmcblk --fstype=ext4 --label root --align 4096 --uuid=70672ec3-5eee-49ff-b3b1-eb1fbd406bf5
 
-bootloader --ptable msdos
+bootloader --ptable gpt
 


### PR DESCRIPTION
Add a part uuid to correspond to the original coral mendel partitions and change bootloader partition table to gpt to be able to flash the emmc.

Signed-off-by: Benjamin DELATTRE <benjamin.delattre@outlook.com>
(cherry picked from commit f7b79dd5122bbf3dc6dc2acaab4c2b55fae3e7e4)