### PR TITLE
Enable the wifi radio on the coral dev board

### DIFF
--- a/meta-coral-bsp/conf/machine/coral-dev.conf
+++ b/meta-coral-bsp/conf/machine/coral-dev.conf
@@ -21,6 +21,8 @@ MACHINE_FEATURES += "wifi bluetooth optee qca6174"
 MACHINE_EXTRA_RDEPENDS += "\
     kernel-modules \
     libedgetpu \
+    firmware-qca6174 \
+    kernel-module-qca6174 \
 "
 
 MACHINE_SOCARCH_FILTER_append_mx8mq = " \


### PR DESCRIPTION
Add the packages for the qca6174 kernel module and firmware.  This will
enable the wifi radio on the coral dev board.