### PR TITLE
Add usb gadget support

### DIFF
--- a/meta-coral-bsp/conf/machine/coral-dev.conf
+++ b/meta-coral-bsp/conf/machine/coral-dev.conf
@@ -21,6 +21,7 @@ MACHINE_FEATURES += "wifi bluetooth optee qca6174"
 MACHINE_EXTRA_RDEPENDS += "\
     kernel-modules \
     libedgetpu \
+    usb-gadget \
 "
 
 MACHINE_SOCARCH_FILTER_append_mx8mq = " \

--- a/meta-coral-bsp/recipes-bsp/usb-gadget/files/usb-gadget.init
+++ b/meta-coral-bsp/recipes-bsp/usb-gadget/files/usb-gadget.init
@@ -1,0 +1,36 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          usb-gadget
+### END INIT INFO
+
+# /etc/init.d init script for usb-gadget
+
+start() {
+  # start the usb gadget
+  /usr/bin/usb-gadget-start.sh
+  # start getty on ttyGS0
+  /sbin/agetty -8 -c -w --noclear ttyGS0 $TERM
+  echo 'usb-gadget started' >&2
+}
+
+stop() {
+  /usr/bin/usb-gadget-stop.sh
+  # stop getty on ttyGS0
+  kill -9 `ps ax | grep agetty | grep ttyGS0 -m 1 | awk '{print $1}'`
+  echo 'usb-gadget stoped' >&2
+}
+
+case "$1" in
+  start)
+    start
+    ;;
+  stop)
+    stop
+    ;;
+  restart)
+    stop
+    start
+    ;;
+  *)
+    echo "Usage: $0 {start|stop|restart}"
+esac

--- a/meta-coral-bsp/recipes-bsp/usb-gadget/usb-gadget_git.bb
+++ b/meta-coral-bsp/recipes-bsp/usb-gadget/usb-gadget_git.bb
@@ -1,0 +1,42 @@
+SUMMARY = "USB Gagdget Services"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://debian/copyright;md5=90b825e31d1d74dc87b4888a30271e33"
+
+SRC_URI = "git://coral.googlesource.com/usb-gadget;protocol=https \
+           file://usb-gadget.init \
+"
+
+SRCREV ="15d2ebc5fdccbbe6699c109ea0a5335a921037de"
+RDEPENDS_${PN} += "bash networkmanager"
+
+inherit update-rc.d systemd
+PACKAGES =+ "${PN}-gs0"
+S = "${WORKDIR}/git"
+
+INITSCRIPT_NAME = "usb-gadget"
+SYSTEMD_PACKAGES = "${PN} ${PN}-gs0"
+SYSTEMD_SERVICE_${PN} = "usb-gadget.service"
+SYSTEMD_SERVICE_${PN}-gs0 = "usb-gadget-getty-ttyGS0.service"
+SYSTEMD_AUTO_ENABLE_${PN} = "enable"
+SYSTEMD_AUTO_ENABLE_${PN}-gs0 = "enable"
+
+do_install() {
+        # Install init scripts and set correct config directory
+        install -d ${D}${sysconfdir}/init.d
+        install -m 0755 ${WORKDIR}/usb-gadget.init  ${D}${sysconfdir}/init.d/usb-gadget
+        # Install systemd unit files
+        install -d ${D}${systemd_unitdir}/system
+        install -m 0644 ${S}/debian/usb-gadget.service ${D}${systemd_unitdir}/system
+        install -m 0644 ${S}/debian/usb-gadget-getty-ttyGS0.service ${D}${systemd_unitdir}/system
+        # Install start/stop scripts
+        install -d ${D}${bindir}
+        install -m 0755 ${S}/usr/bin/usb-gadget-start.sh ${D}${bindir}/
+        install -m 0755 ${S}/usr/bin/usb-gadget-stop.sh ${D}${bindir}/
+        # Install dnsmasq config
+        install -d ${D}${sysconfdir}/dnsmasq.d
+        install -m 0644 ${S}/etc/dnsmasq.d/02-usb-gadget ${D}${sysconfdir}/dnsmasq.d
+        install -m 0644 ${S}/etc/dnsmasq.d/99-no-default-dns ${D}${sysconfdir}/dnsmasq.d
+        install -m 0644 ${S}/etc/dnsmasq.d/99-no-default-route ${D}${sysconfdir}/dnsmasq.d
+}
+
+FILES_${PN} = "${bindir} ${sysconfdir} ${systemd_unitdir}"


### PR DESCRIPTION
From the Mendel OS source package (https://coral.googlesource.com/usb-gadget)
add the scripts and service files to enable USB gadget support. This
should enable networking and a console over USB.

Signed-off-by: frank agius <ftagius@gmail.com>