### PR TITLE
conf/layer.conf: add more versions to LAYERSERIES_COMPAT

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -8,6 +8,6 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 BBFILE_COLLECTIONS += "coral-bsp"
 BBFILE_PATTERN_coral-bsp := "^${LAYERDIR}/"
 BBFILE_PRIORITY_coral-bsp = "6"
-LAYERSERIES_COMPAT_coral-bsp = "mickledore"
+LAYERSERIES_COMPAT_coral-bsp = "nanbield scarthgap"
 
 LAYERDEPENDS_coral-bsp = "core freescale-layer clang-layer"


### PR DESCRIPTION
Add compatibility with the two current releases. Only boot tested building from master branch which should be close to the 'scarthgap' release (next LTS).