### PR TITLE
Fix: imx-boot missing when building core-image-base #66

### DIFF
--- a/conf/machine/coral-dev.conf
+++ b/conf/machine/coral-dev.conf
@@ -40,7 +40,7 @@ UBOOT_CONFIG ??= "sd"
 UBOOT_CONFIG[sd] = "imx8mq_phanbell_defconfig,sdcard"
 UBOOT_CONFIG[mfgtool]  = "imx8mq_phanbell_defconfig"
 
-UBOOT_PROVIDES_BOOT_CONTAINER = "0"
+UBOOT_PROVIDES_BOOT_CONTAINER:mx8m-generic-bsp = "0"
 
 SPL_BINARY = "spl/u-boot-spl.bin"
 


### PR DESCRIPTION
* set UBOOT_PROVIDES_BOOT_CONTAINER:mx8m-generic-bsp = "0" in machine config