### PR TITLE
u-boot-coral: don't deploy a conflicting boot.scr if UBOOT_ENV is set

### DIFF
--- a/recipes-bsp/u-boot/u-boot-coral_2019.04.bb
+++ b/recipes-bsp/u-boot/u-boot-coral_2019.04.bb
@@ -2,7 +2,11 @@ DESCRIPTION = "Coral U-Boot suppporting the Google Coral Dev board/SOM"
 require recipes-bsp/u-boot/u-boot-common.inc
 require recipes-bsp/u-boot/u-boot.inc
 
-DEPENDS += "flex-native bison-native coral-boot-script"
+DEPENDS += " \
+	flex-native \
+	bison-native \
+	${@oe.utils.conditional('UBOOT_ENV', '', 'coral-boot-script', '', d)} \
+	"
 
 PROVIDES += "u-boot"
 


### PR DESCRIPTION
This can happen if a user of meta-coral uses UBOOT_ENV to ship a common boot.scr for various platforms/machines.